### PR TITLE
Fixes for Seaborn 0.12.0

### DIFF
--- a/src/psifr/fr.py
+++ b/src/psifr/fr.py
@@ -1783,7 +1783,7 @@ def plot_lag_crp(recall, max_lag=5, lag_key='lag', split=True, **facet_kws):
     if split:
         filt_neg = f'{-max_lag} <= {lag_key} < 0'
         filt_pos = f'0 < {lag_key} <= {max_lag}'
-        g = sns.FacetGrid(dropna=False, **facet_kws, data=recall.reset_index())
+        g = sns.FacetGrid(dropna=True, **facet_kws, data=recall.reset_index())
         g.map_dataframe(
             lambda data, **kws: sns.lineplot(
                 data=data.query(filt_neg), x=lag_key, y='prob', **kws

--- a/src/psifr/fr.py
+++ b/src/psifr/fr.py
@@ -1869,7 +1869,7 @@ def plot_swarm_error(
         sns.swarmplot, x=x, y=y, color=swarm_color, size=swarm_size, zorder=1
     )
     g.map_dataframe(
-        sns.pointplot, x=x, y=y, color=point_color, join=False, capsize=0.5, linewidth=1
+        sns.pointplot, x=x, y=y, color=point_color, join=False, capsize=0.5
     )
     return g
 


### PR DESCRIPTION
Make two small changes to fix support for Seaborn 0.12.0. 

First, there seems to be a bug when a `DataFrame` with only NA data is passed to `sns.lineplot`. This can be avoided within `plot_lag_crp` by using `dropna=True` when setting up the `sns.FacetGrid`. I don't think this will cause any problems with other use cases.

Second, in `plot_swarm_error`, the `linewidth` argument that was previously accepted by `sns.pointplot` is no longer accepted. That argument has now been removed. If linewidth customization is needed, it will have to be handled outside `plot_swarm_error`.

Closes #13.